### PR TITLE
Support for private cloud

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -45,6 +45,15 @@ inputs:
       is_required: true
       is_expand: true
       is_sensitive: true
+  - server_endpoint: ""
+    opts:
+      title: Private cloud endpoint
+      summary: Private cloud endpoint for TestFairy
+      description: |-
+        If you are using a private cloud endpoint for TestFairy, specify it here
+      is_required: false
+      is_expand: false
+      is_sensitive: false
   - ipa_path: "$BITRISE_IPA_PATH"
     opts:
       title: IPA path

--- a/testfairy-upload-ios.sh
+++ b/testfairy-upload-ios.sh
@@ -55,6 +55,10 @@ verify_settings() {
 		echo "Please update API_KEY with your private API key, as noted in the Settings page"
 		exit 1
 	fi
+
+	if ![ -z "${server_endpoint}" ]; then
+		SERVER_ENDPOINT=${server_endpoint}
+	fi
 }
 
 if [ $# -ne 1 ]; then


### PR DESCRIPTION
# Description
This PR adds support for private cloud integration in TestFairy. See [this](https://docs.testfairy.com/SDK/Private_Cloud_Integration.html) page. This will default to the usual TestFairy endpoint, unless specified otherwise.

# Testing
Guys - what's the best way to test this? Local Docker run?