### PR TITLE
Fixed syntax error when setting server_endpoint step input

### DIFF
--- a/testfairy-upload-ios.sh
+++ b/testfairy-upload-ios.sh
@@ -56,7 +56,7 @@ verify_settings() {
 		exit 1
 	fi
 
-	if ![ -z "${server_endpoint}" ]; then
+	if [ ! -z "${server_endpoint}" ]; then
 		SERVER_ENDPOINT=${server_endpoint}
 	fi
 }


### PR DESCRIPTION
There was a typo/syntax error in the code which caused the `server_endpoint` never being set:
`testfairy-upload-ios.sh: line 59: ![: command not found`