### PR TITLE
Update testfairy-upload-ios.sh to get the direct download URL

### DIFF
--- a/testfairy-upload-ios.sh
+++ b/testfairy-upload-ios.sh
@@ -89,13 +89,14 @@ fi
 
 MESSAGE=$( echo ${JSON} | sed 's/\\\//\//g' | sed -n 's/.*"message"\s*:\s*"\([^"]*\)".*/\1/p' )
 URL=$( echo ${JSON} | sed 's/\\\//\//g' | sed -n 's/.*"build_url"\s*:\s*"\([^"]*\)".*/\1/p' )
+APP_URL=$( echo ${JSON} | sed 's/\\\//\//g' | sed -n 's/.*"app_url"\s*:\s*"\([^"]*\)".*/\1/p' )
 
 if [ ! -z "$MESSAGE" ]; then
 	write_section_to_formatted_output "## Deploy Failed"
 	echo_string_to_formatted_output "Failed to upload the build due to the following error:"
 	echo_string_to_formatted_output "$MESSAGE"
 	exit 1
-elif [ -z "$URL" ]; then
+elif [ -z "$URL" ] || [ -z "$APP_URL" ]; then
 	write_section_to_formatted_output "## Deploy Failed"
 	echo_string_to_formatted_output "Build uploaded, but no reply from server. Please contact support@testfairy.com"
 	exit 1
@@ -103,7 +104,9 @@ fi
 
 write_section_to_formatted_output "## Deploy Success"
 echo_string_to_formatted_output "* **Build URL**: [${URL}](${URL})"
+echo_string_to_formatted_output "* **APP URL**: [${APP_URL}](${APP_URL})"
 
 envman add --key TESTFAIRY_PUBLIC_INSTALL_PAGE_URL --value "${URL}"
+envman add --key TESTFAIRY_APP_URL --value "${APP_URL}"
 
 exit 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

  Quick fix to get the direct download URL, as now, the url given requires users to be logged in.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

- Added app_url to the list of variables get from the JSON.
- Added this value into a returned variable on bitrise.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
